### PR TITLE
Don't throw an exception for a test address that doesn't include a class...

### DIFF
--- a/box/test/flaky/_flaky_plugin.py
+++ b/box/test/flaky/_flaky_plugin.py
@@ -54,7 +54,12 @@ class _FlakyPlugin(object):
         :rtype:
             `bool`
         """
-        test_method, test_method_name = self._get_test_method_and_name(test)
+        try:
+            test_method, test_method_name = self._get_test_method_and_name(
+                test
+            )
+        except AttributeError:
+            return False
         current_runs = self._get_flaky_attribute(
             test_method,
             FlakyNames.CURRENT_RUNS,

--- a/test/test_flaky_nose_plugin.py
+++ b/test/test_flaky_nose_plugin.py
@@ -76,6 +76,15 @@ class TestFlakyPlugin(TestCase):
         self._flaky_plugin.handleFailure(self._mock_test_case, None)
         self._assert_test_ignored()
 
+    def test_flaky_plugin_ignores_error_for_nose_failure(self):
+        self._mock_test_case.address.return_value = (
+            None,
+            self._mock_test_module_name,
+            None,
+        )
+        self._flaky_plugin.handleError(self._mock_test_case, None)
+        self._assert_test_ignored()
+
     def test_flaky_plugin_handles_error_for_test_method(self):
         self._test_flaky_plugin_handles_failure_or_error()
 


### PR DESCRIPTION
... and method name.

This usually indicates another exception that is being swallowed.  Just return false and let the test runner handle the failure.
