### PR TITLE
Fix false successful exit status

### DIFF
--- a/flaky/flaky_nose_plugin.py
+++ b/flaky/flaky_nose_plugin.py
@@ -5,7 +5,6 @@ import logging
 from optparse import OptionGroup
 from nose.failure import Failure
 from nose.plugins import Plugin
-from nose.result import TextTestResult
 import os
 
 from flaky._flaky_plugin import _FlakyPlugin
@@ -20,7 +19,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
     def __init__(self):
         super(FlakyPlugin, self).__init__()
         self._logger = logging.getLogger('nose.plugins.flaky')
-        self._flaky_result = TextTestResult(self._stream, [], 0)
+        self._flaky_result = None
         self._flaky_report = True
         self._force_flaky = False
         self._max_runs = None
@@ -48,6 +47,17 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
         self._force_flaky = options.force_flaky
         self._max_runs = options.max_runs
         self._min_passes = options.min_passes
+
+    def prepareTestResult(self, orig_result):
+        """
+        Executed on first call of this plugin.
+        :param orig_result:
+            `self._flaky_result` will be updated to `orig_result`
+        :type orig_result:
+            :class:`nose.result.TextTestResult`
+        """
+        # pylint:disable=invalid-name
+        self._flaky_result = orig_result
 
     def handleError(self, test, err):
         """

--- a/test/test_flaky_nose_plugin.py
+++ b/test/test_flaky_nose_plugin.py
@@ -16,13 +16,11 @@ class TestFlakyPlugin(TestCase):
         super(TestFlakyPlugin, self).setUp()
 
         test_base_mod = 'flaky._flaky_plugin'
-        self._mock_test_result = MagicMock()
+        self._mock_test_result = None
         self._mock_stream = MagicMock(spec=StringIO)
-        with patch.object(flaky_nose_plugin, 'TextTestResult') as flaky_result:
-            with patch(test_base_mod + '.StringIO') as string_io:
-                string_io.return_value = self._mock_stream
-                flaky_result.return_value = self._mock_test_result
-                self._flaky_plugin = flaky_nose_plugin.FlakyPlugin()
+        with patch(test_base_mod + '.StringIO') as string_io:
+            string_io.return_value = self._mock_stream
+            self._flaky_plugin = flaky_nose_plugin.FlakyPlugin()
         self._mock_test = MagicMock(name='flaky_plugin_test')
         self._mock_test_case = MagicMock(
             name='flaky_plugin_test_case',

--- a/test/test_options_example.py
+++ b/test/test_options_example.py
@@ -15,13 +15,14 @@ class ExampleTests(TestCase):
 
     def test_something_flaky(self):
         """
-        Flaky will run this test 3 times.
-        It will fail twice and then succeed once.
+        Flaky will run this test 2 times.
+        It will fail once and then succeed once.
         This ensures that we mark tests as flaky even if they don't have a
-        decorator when we use the command-line options.
+        decorator when we use the command-line options, specifically
+        `--max-runs=2`.
         """
         self._threshold += 1
-        if self._threshold < 1:
+        if self._threshold < 0:
             raise Exception("Threshold is not high enough.")
 
     @flaky(3, 1)


### PR DESCRIPTION
This PR addresses issue https://github.com/box/flaky/issues/25.

Adds a `prepareTestResult` method to set `_flaky_result` to the `TextTestResult` object that is passed from nose, and updates the tests in `test_flaky_nose_plugin.py` accordingly.

Additionally, it fixes an existing failure in `test_options_example.py` that now would cause a failed travis build.
