### PR TITLE
Copy flaky attributes to collected tests.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,7 +3,7 @@
 Release History
 ---------------
 
-2.0.4 (2015-04-16)
+2.0.4 (2015-04-20)
 ++++++++++++++++++
 
 **Bugfixes**
@@ -11,7 +11,11 @@ Release History
 - Flaky now copies flaky attributes to collected tests, rather than modifying them on the test declaration.
   This means that tests collected from classes that inherit tests marked flaky (from a base class) will now
   work correctly.
+
 - Running py.test with doctests will no longer cause the doctests to fail. Doctests cannot, however, be marked flaky.
+
+- Tests marked flaky will now be correctly rerun from pytest when using the pytest-xdist option. However, they
+  will not be run if the `--boxed` option is used due to a technical limitation.
 
 **Documentation updates**
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,20 @@
 Release History
 ---------------
 
+2.0.4 (2015-04-16)
+++++++++++++++++++
+
+**Bugfixes**
+
+- Flaky now copies flaky attributes to collected tests, rather than modifying them on the test declaration.
+  This means that tests collected from classes that inherit tests marked flaky (from a base class) will now
+  work correctly.
+- Running py.test with doctests will no longer cause the doctests to fail. Doctests cannot, however, be marked flaky.
+
+**Documentation updates**
+
+- Updated documentation to correctly specify how to suppress the flaky report under py.test.
+
 2.0.3 (2015-03-20)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,16 @@ To install, simply:
     pip install flaky
 
 
+Compatibility
+-------------
+
+Flaky is tested with the following test runners and options:
+
+- Nosetests. Doctests cannot be marked flaky.
+
+- Py.test. Works with `pytest-xdist` but not with the `--boxed` option. Doctests cannot be marked flaky.
+
+
 Contributing
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ With py.test, flaky will automatically run. It can, however be disabled via the 
 
 .. code-block:: console
 
-    py.test no:flaky
+    py.test -p no:flaky
 
 Command line arguments
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/flaky/flaky_nose_plugin.py
+++ b/flaky/flaky_nose_plugin.py
@@ -166,7 +166,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
             test_class = test.test
             self._copy_flaky_attributes(test, test_class)
             if self._force_flaky and not self._has_flaky_attributes(test):
-                self._make_test_callable_flaky(
+                self._make_test_flaky(
                     test, self._max_runs, self._min_passes)
 
     def _rerun_test(self, test):
@@ -192,17 +192,18 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
         return test_callable_name
 
     @classmethod
-    def _get_test_callable_and_name(cls, test):
+    def _get_test_declaration_callable_and_name(cls, test):
         """
-        Get the test callable and test callable name from the test.
+        Base class override.
+
         :param test:
             The test that has raised an error or succeeded
         :type test:
             :class:`nose.case.Test`
         :return:
-            The test callable (and its name) that is being run by the test
+            The test declaration, callable and name that is being run
         :rtype:
-            `tuple` of `callable`, `unicode`
+            `tuple` of `object`, `callable`, `unicode`
         """
         callable_name = cls._get_test_callable_name(test)
         test_callable = getattr(
@@ -210,4 +211,4 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
             callable_name,
             getattr(test.test, 'test', test.test),
         )
-        return test_callable, callable_name
+        return test_callable, test_callable, callable_name

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -101,7 +101,7 @@ class FlakyPlugin(_FlakyPlugin):
         test_instance = self._get_test_instance(item)
         self._copy_flaky_attributes(item, test_instance)
         if self.force_flaky and not self._has_flaky_attributes(item):
-            self._make_test_callable_flaky(
+            self._make_test_flaky(
                 item,
                 self.max_runs,
                 self.min_passes,
@@ -203,26 +203,31 @@ class FlakyPlugin(_FlakyPlugin):
         return test.name
 
     @classmethod
-    def _get_test_callable_and_name(cls, test):
+    def _get_test_declaration_callable_and_name(cls, test):
         """
-        Get the test callable and test callable name from the test.
+        Base class override.
+
         :param test:
             The test that has raised an error or succeeded
         :type test:
             :class:`Function`
         :return:
-            The test callable (and its name) that is being run by the test
+            The test declaration, callable and name that is being run
         :rtype:
-            `tuple` of `callable`, `unicode`
+            `tuple` of `object`, `callable`, `unicode`
         """
         callable_name = cls._get_test_callable_name(test)
         test_instance = cls._get_test_instance(test)
         if hasattr(test_instance, callable_name):
-            return getattr(test_instance, callable_name), callable_name
+            def_and_callable = getattr(test_instance, callable_name)
+            return def_and_callable, def_and_callable, callable_name
+        elif hasattr(test, 'runner') and hasattr(test.runner, 'run'):
+            return test, test.runner.run, callable_name
         elif hasattr(test.module, callable_name):
-            return getattr(test.module, callable_name), callable_name
+            def_and_callable = getattr(test.module, callable_name)
+            return def_and_callable, def_and_callable, callable_name
         else:
-            return None, callable_name
+            return None, None, callable_name
 
     def _rerun_test(self, test):
         """Base class override. Rerun a flaky test."""

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def main():
     base_dir = dirname(__file__)
     setup(
         name='flaky',
-        version='2.0.3',
+        version='2.0.4',
         description='Plugin for nose or py.test that automatically reruns flaky tests.',
         long_description=open(join(base_dir, 'README.rst')).read(),
         author='Box',

--- a/test/test_pytest_example.py
+++ b/test/test_pytest_example.py
@@ -88,3 +88,16 @@ class TestExampleFlakyTestCase(TestCase):
         """
         self._threshold += 1
         assert self._threshold >= 1
+
+
+class TestFlakySubclass(TestExampleFlakyTestCase):
+    pass
+
+
+def _test_flaky_doctest():
+    """
+    Flaky ignored doctests. This test wouldn't be rerun if it failed.
+    >>> _test_flaky_doctest()
+    True
+    """
+    return True

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     python setup.py develop
     nosetests --with-flaky --exclude="pytest|test_options_example"
     py.test test/test_pytest_example.py
-    py.test -p no:flaky test/test_flaky_pytest_plugin.py
+    py.test -p no:flaky --doctest-modules test/test_flaky_pytest_plugin.py
     nosetests --with-flaky --force-flaky --max-runs 2 test/test_options_example.py
     py.test --force-flaky --max-runs 2  test/test_pytest_options_example.py
 


### PR DESCRIPTION
This allows the same test declaration to be collected multiple times without problems.
Also fixes a documentation error.
Fixes #36 Fixes #34 Fixes #33