### PR TITLE
Catch UnicodeEncodeErrors in _add_flaky_report()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,9 @@ Release History
 
 - Flaky will no longer raise a KeyError for failed flaky tests.
 
+- Flaky will no longer raise a UnicodeEncodeError for flaky tests which raise exceptions
+  with non-ascii characters.
+
 2.1.0 (2015-05-05)
 ++++++++++++++++++
 

--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -233,7 +233,11 @@ class _FlakyPlugin(object):
             `file`
         """
         stream.write('===Flaky Test Report===\n\n')
-        stream.write(self._stream.getvalue())
+        value = self._stream.getvalue()
+        try:
+            stream.write(value)
+        except UnicodeEncodeError:
+            stream.write(value.encode('utf-8', 'replace'))
         stream.write('\n===End Flaky Test Report===\n')
 
     @classmethod

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -93,9 +93,9 @@ def test_flaky_function(param=[]):
 class ExampleFlakyTestsWithUnicodeTestNames(ExampleFlakyTests):
     @genty_dataset('ascii name', 'ńőń ȁŝćȉȉ ŝƭȕƒƒ')
     def test_non_flaky_thing(self, message):
-        # pylint:disable=unused-argument
         self._threshold += 1
         if self._threshold < 1:
-            raise Exception("Threshold is not high enough: {0} vs {1}.".format(
-                self._threshold, 1),
+            raise Exception(
+                "Threshold is not high enough: {0} vs {1} for '{2}'.".format(
+                    self._threshold, 1, message),
             )


### PR DESCRIPTION
Fixes #47.
Catch a UncodeEncodeError when writing to the stream, and encode using
utf-8 if needed.