### PR TITLE
Modify flaky to work with pytest parametrized tests.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Upcoming
 - Flaky will no longer raise a UnicodeEncodeError for flaky tests which raise exceptions
   with non-ascii characters.
 - Flaky will no longer cause nose to report non-flaky test failures and errors twice.
+- Flaky now works with tests that are parametrized with py.test.
 
 
 2.1.1 (2015-05-22)

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -240,14 +240,29 @@ class FlakyPlugin(_FlakyPlugin):
             `tuple` of `object`, `callable`, `unicode`
         """
         callable_name = cls._get_test_callable_name(test)
+        if callable_name.endswith(']') and '[' in callable_name:
+            unparametrized_name = callable_name[:callable_name.index('[')]
+        else:
+            unparametrized_name = callable_name
         test_instance = cls._get_test_instance(test)
         if hasattr(test_instance, callable_name):
+            # Test is a method of a class
             def_and_callable = getattr(test_instance, callable_name)
             return def_and_callable, def_and_callable, callable_name
+        elif hasattr(test_instance, unparametrized_name):
+            # Test is a parametrized method of a class
+            def_and_callable = getattr(test_instance, unparametrized_name)
+            return def_and_callable, def_and_callable, callable_name
         elif hasattr(test, 'runner') and hasattr(test.runner, 'run'):
+            # Test is a doctest
             return test, test.runner.run, callable_name
         elif hasattr(test.module, callable_name):
+            # Test is a function in a module
             def_and_callable = getattr(test.module, callable_name)
+            return def_and_callable, def_and_callable, callable_name
+        elif hasattr(test.module, unparametrized_name):
+            # Test is a parametrized function in a module
+            def_and_callable = getattr(test.module, unparametrized_name)
             return def_and_callable, def_and_callable, callable_name
         else:
             return None, None, callable_name

--- a/test/pytest_generate_example/__init__.py
+++ b/test/pytest_generate_example/__init__.py
@@ -1,0 +1,3 @@
+# coding: utf-8
+
+from __future__ import unicode_literals

--- a/test/pytest_generate_example/conftest.py
+++ b/test/pytest_generate_example/conftest.py
@@ -1,0 +1,8 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+
+def pytest_generate_tests(metafunc):
+    if 'dummy_list' in metafunc.fixturenames:
+        metafunc.parametrize("dummy_list", [[]])

--- a/test/pytest_generate_example/test_pytest_generate_example.py
+++ b/test/pytest_generate_example/test_pytest_generate_example.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+from flaky import flaky
+
+
+@flaky
+def test_something_flaky(dummy_list):
+    # pylint:disable=dangerous-default-value
+    dummy_list.append(0)
+    assert len(dummy_list) > 1
+
+
+class TestExample(object):
+    _threshold = -1
+
+    @flaky
+    def test_flaky_thing_that_fails_then_succeeds(self, dummy_list):
+        self._threshold += 1
+        assert self._threshold >= 1

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps = -rrequirements-dev.txt
 usedevelop = True
 commands =
     nosetests --with-flaky --exclude="pytest|test_options_example"
-    py.test test/test_pytest_example.py
+    py.test -k 'example and not options'
     py.test -p no:flaky --doctest-modules test/test_flaky_pytest_plugin.py
     nosetests --with-flaky --force-flaky --max-runs 2 test/test_options_example.py
     py.test --force-flaky --max-runs 2  test/test_pytest_options_example.py
@@ -34,7 +34,7 @@ commands =
 commands =
     python setup.py develop
     nosetests --with-flaky --with-coverage --cover-package=flaky --exclude="pytest|test_options_example"
-    py.test --cov flaky test/test_pytest_example.py
+    py.test -k 'example and not options' --cov flaky
     py.test -p no:flaky --cov flaky test/test_flaky_pytest_plugin.py
 
 [testenv:readme]


### PR DESCRIPTION
Fixes #51.

When using metafunc.parametrize to parametrize tests, the test name includes information about the parameters in square brackets.
However, these aren't "real" functions, so flaky wasn't able to find the @flaky decorator.
This commit adds code to look for square brackets and look for unparametrized functions.