### PR TITLE
Add ability to skip flaky rerun.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Release History
 Upcoming
 ++++++++
 
+- The `@flaky` decorator now accepts a `rerun_filter` parameter.
+  This allows for failing certain types of failures/errors immediately instead of rerunning.
+
 2.1.2 (2015-07-30)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,27 @@ In addition to marking a single test flaky, entire test cases can be marked flak
 The @flaky class decorator will mark test_flaky_doubler as flaky, but it won't override the 3 max_runs
 for test_flaky_tripler (from the decorator on that test method).
 
+Don't rerun certain types of failures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Depending on your tests, some failures are obviously not due to flakiness. Instead of rerunning
+after those failures, you can specify a filter function that can tell flaky to fail the test right away.
+
+.. code-block:: python
+
+    def is_not_crash(err, *args):
+        return not issubclass(err[0], ProductCrashedError)
+
+    @flaky
+    def test_something():
+        raise ProductCrashedError
+
+    @flaky(rerun_filter=is_not_crash)
+    def test_something_else():
+        raise ProductCrashedError
+
+Flaky will run `test_something` twice, but will only run `test_something_else` once.
+
 Activating the plugin
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -18,6 +18,14 @@ class _FlakyPlugin(object):
 
     @property
     def stream(self):
+        """
+        Returns the stream used for building the flaky report.
+        Anything written to this stream before the end of the test run
+        will be written to the flaky report.
+
+        :return:
+        :rtype:
+        """
         return self._stream
 
     def _log_test_failure(self, test_callable_name, err, message):
@@ -43,6 +51,19 @@ class _FlakyPlugin(object):
         least min_passes times.
 
         By default, this means that the test has failed twice.
+
+        :param err:
+            Information about the test failure (from sys.exc_info())
+        :type err:
+            `tuple` of `class`, :class:`Exception`, `traceback`
+        :param flaky:
+            Dictionary of flaky attributes
+        :type flaky:
+            `dict` of `unicode` to varies
+        :param name:
+            The test name
+        :type name:
+            `unicode`
         """
         min_passes = flaky[FlakyNames.MIN_PASSES]
         current_passes = flaky[FlakyNames.CURRENT_PASSES]
@@ -56,6 +77,19 @@ class _FlakyPlugin(object):
         """
         Report that the test has failed, but still has reruns left.
         Then rerun the test.
+
+        :param err:
+            Information about the test failure (from sys.exc_info())
+        :type err:
+            `tuple` of `class`, :class:`Exception`, `traceback`
+        :param flaky:
+            Dictionary of flaky attributes
+        :type flaky:
+            `dict` of `unicode` to varies
+        :param name:
+            The test name
+        :type name:
+            `unicode`
         """
         max_runs = flaky[FlakyNames.MAX_RUNS]
         runs_left = max_runs - flaky[FlakyNames.CURRENT_RUNS]

--- a/flaky/defaults.py
+++ b/flaky/defaults.py
@@ -3,7 +3,7 @@
 from flaky.names import FlakyNames
 
 
-def true(*args):
+def _true(*args):
     """
     Default rerun filter function that always returns True.
     """
@@ -49,5 +49,5 @@ def default_flaky_attributes(max_runs, min_passes, rerun_filter=None):
         FlakyNames.MIN_PASSES: min_passes,
         FlakyNames.CURRENT_RUNS: 0,
         FlakyNames.CURRENT_PASSES: 0,
-        FlakyNames.RERUN_FILTER: FilterWrapper(rerun_filter or true),
+        FlakyNames.RERUN_FILTER: FilterWrapper(rerun_filter or _true),
     }

--- a/flaky/defaults.py
+++ b/flaky/defaults.py
@@ -3,7 +3,28 @@
 from flaky.names import FlakyNames
 
 
-def default_flaky_attributes(max_runs, min_passes):
+def true(*args):
+    """
+    Default rerun filter function that always returns True.
+    """
+    # pylint:disable=unused-argument
+    return True
+
+
+class FilterWrapper(object):
+    """
+    Filter function wrapper. Expected to be called as though it's a filter
+    function. Since @flaky adds attributes to a decorated class, Python wants
+    to turn a bare function into an unbound method, which is not what we want.
+    """
+    def __init__(self, rerun_filter):
+        self._filter = rerun_filter
+
+    def __call__(self, *args, **kwargs):
+        return self._filter(*args, **kwargs)
+
+
+def default_flaky_attributes(max_runs, min_passes, rerun_filter=None):
     """
     Returns the default flaky attributes to set on a flaky test.
     :param max_runs:
@@ -14,7 +35,12 @@ def default_flaky_attributes(max_runs, min_passes):
         The value of the FlakyNames.MIN_PASSES attribute to use.
     :type min_passes:
         `int`
+    :param rerun_filter:
+        Filter function to decide whether a test should be rerun if it fails.
+    :type rerun_filter:
+        `callable`
     :return:
+        Default flaky attributes to set on a flaky test.
     :rtype:
         `dict`
     """
@@ -23,4 +49,5 @@ def default_flaky_attributes(max_runs, min_passes):
         FlakyNames.MIN_PASSES: min_passes,
         FlakyNames.CURRENT_RUNS: 0,
         FlakyNames.CURRENT_PASSES: 0,
+        FlakyNames.RERUN_FILTER: FilterWrapper(rerun_filter or true),
     }

--- a/flaky/flaky_decorator.py
+++ b/flaky/flaky_decorator.py
@@ -38,19 +38,18 @@ def flaky(max_runs=None, min_passes=None, rerun_filter=None):
     :rtype:
         `callable`
     """
+    # In case @flaky is applied to a function or class without arguments
+    # (and without parentheses), max_runs will refer to the wrapped object.
+    # In this case, the default value can be used.
+    wrapped = None
+    if hasattr(max_runs, '__call__'):
+        wrapped, max_runs = max_runs, None
     if max_runs is None:
         max_runs = 2
     if min_passes is None:
         min_passes = 1
     if min_passes <= 0:
         raise ValueError('min_passes must be positive')
-    # In case @flaky is applied to a function or class without arguments
-    # (and without parentheses), max_runs will refer to the wrapped object.
-    # In this case, the default value can be used.
-    wrapped = None
-    if hasattr(max_runs, '__call__'):
-        wrapped = max_runs
-        max_runs = 2
     if max_runs < min_passes:
         raise ValueError('min_passes cannot be greater than max_runs!')
 

--- a/flaky/flaky_decorator.py
+++ b/flaky/flaky_decorator.py
@@ -2,10 +2,10 @@
 
 from __future__ import unicode_literals
 
-from flaky import defaults
+from flaky.defaults import default_flaky_attributes
 
 
-def flaky(max_runs=None, min_passes=None):
+def flaky(max_runs=None, min_passes=None, rerun_filter=None):
     """
     Decorator used to mark a test as "flaky". When used in conjuction with
     the flaky nosetests plugin, will cause the decorated test to be retried
@@ -18,6 +18,21 @@ def flaky(max_runs=None, min_passes=None):
         The minimum number of times the test must pass to be a success.
     :type min_passes:
         `int`
+    :param rerun_filter:
+        Filter function to decide whether a test should be rerun if it fails.
+        Function signature is as follows:
+            (err, name, test, plugin) -> should_rerun
+        - err (`tuple` of `class`, :class:`Exception`, `traceback`):
+            Information about the test failure (from sys.exc_info())
+        - name (`unicode`):
+            The test name
+        - test (:class:`nose.case.Test` or :class:`Function`):
+            The test that has raised an error
+        - plugin (:class:`FlakyNosePlugin` or :class:`FlakyPytestPlugin`):
+            The flaky plugin. Has a :prop:`stream` that can be written to in
+            order to add to the Flaky Report.
+    :type rerun_filter:
+        `callable`
     :return:
         A wrapper function that includes attributes describing the flaky test.
     :rtype:
@@ -39,7 +54,7 @@ def flaky(max_runs=None, min_passes=None):
     if max_runs < min_passes:
         raise ValueError('min_passes cannot be greater than max_runs!')
 
-    attrib = defaults.default_flaky_attributes(max_runs, min_passes)
+    attrib = default_flaky_attributes(max_runs, min_passes, rerun_filter)
 
     def wrapper(wrapped_object):
         for name, value in attrib.items():

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -91,10 +91,6 @@ class FlakyPlugin(_FlakyPlugin):
     min_passes = None
     config = None
 
-    @property
-    def stream(self):
-        return self._stream
-
     @staticmethod
     def _get_test_instance(item):
         """

--- a/flaky/names.py
+++ b/flaky/names.py
@@ -12,6 +12,7 @@ class FlakyNames(object):
     CURRENT_PASSES = '_flaky_current_passes'
     MAX_RUNS = '_flaky_max_runs'
     MIN_PASSES = '_flaky_min_passes'
+    RERUN_FILTER = '_flaky_rerun_filter'
 
     def __init__(self):
         super(FlakyNames, self).__init__()
@@ -22,7 +23,8 @@ class FlakyNames(object):
             self.CURRENT_PASSES,
             self.CURRENT_RUNS,
             self.MAX_RUNS,
-            self.MIN_PASSES
+            self.MIN_PASSES,
+            self.RERUN_FILTER,
         )
 
     def __iter__(self):

--- a/test/test_flaky_pytest_plugin.py
+++ b/test/test_flaky_pytest_plugin.py
@@ -330,7 +330,16 @@ class TestFlakyPytestPlugin(object):
             mock_error,
             mock_plugin_rerun,
     ):
-        flaky(rerun_filter=lambda *args: False)(flaky_test)
+        err_tuple = (mock_error.type, mock_error.value, mock_error.traceback)
+
+        def rerun_filter(err, name, test, plugin):
+            assert err == err_tuple
+            assert name == flaky_test.name
+            assert test is flaky_test
+            assert plugin is flaky_plugin
+            return False
+
+        flaky(rerun_filter=rerun_filter)(flaky_test)
         call_info.when = 'call'
 
         actual_plugin_handles_failure = flaky_plugin.add_failure(


### PR DESCRIPTION
This commit adds a rerun_filter parameter to @flaky.
When flaky detects a failed test, before rerunning the test, it will call this function, only doing the rerun if it returns True.