### PR TITLE
Add command line option to shorten the flaky report.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Release History
 Upcoming
 ++++++++
 
+- Flaky now accepts a command line option, `--no-success-flaky-report`.
+  When that option is present, flaky won't add information about test successes to the flaky report.
+
 2.1.2 (2015-07-30)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,10 @@ No Flaky Report
 
 Pass ``--no-flaky-report`` to suppress the report at the end of the run detailing flaky test results.
 
+Shorter Flaky Report
+++++++++++++++++++++
+
+Pass ``--no-success-flaky-report`` to suppress information about successful flaky tests.
 
 Force Flaky
 +++++++++++

--- a/flaky.iml
+++ b/flaky.iml
@@ -3,7 +3,6 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/box" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/flaky" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.idea" />

--- a/flaky/flaky_nose_plugin.py
+++ b/flaky/flaky_nose_plugin.py
@@ -47,6 +47,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
         if not self.enabled:
             return
         self._flaky_report = options.flaky_report
+        self._flaky_success_report = options.flaky_success_report
         self._force_flaky = options.force_flaky
         self._max_runs = options.max_runs
         self._min_passes = options.min_passes

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -62,6 +62,7 @@ def pytest_configure(config):
         :class:`Configuration`
     """
     PLUGIN.flaky_report = config.option.flaky_report
+    PLUGIN.flaky_success_report = config.option.flaky_success_report
     PLUGIN.force_flaky = config.option.force_flaky
     PLUGIN.max_runs = config.option.max_runs
     PLUGIN.min_passes = config.option.min_passes
@@ -94,6 +95,14 @@ class FlakyPlugin(_FlakyPlugin):
     @property
     def stream(self):
         return self._stream
+
+    @property
+    def flaky_success_report(self):
+        return self._flaky_success_report
+
+    @flaky_success_report.setter
+    def flaky_success_report(self, value):
+        self._flaky_success_report = value
 
     @staticmethod
     def _get_test_instance(item):

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -98,10 +98,28 @@ class FlakyPlugin(_FlakyPlugin):
 
     @property
     def flaky_success_report(self):
+        """
+        Property for setting whether or not the plugin will print results about
+        flaky tests that were successful.
+
+        :return:
+            Whether or not flaky will report on test successes.
+        :rtype:
+            `bool`
+        """
         return self._flaky_success_report
 
     @flaky_success_report.setter
     def flaky_success_report(self, value):
+        """
+        Property for setting whether or not the plugin will print results about
+        flaky tests that were successful.
+
+        :param value:
+            Whether or not flaky will report on test successes.
+        :type value:
+            `bool`
+        """
         self._flaky_success_report = value
 
     @staticmethod

--- a/test/test_flaky_pytest_plugin.py
+++ b/test/test_flaky_pytest_plugin.py
@@ -189,6 +189,27 @@ def test_flaky_session_finish_copies_flaky_report(
     assert PLUGIN.config.slaveoutput['flaky_report'] == expected_report
 
 
+def test_flaky_plugin_can_suppress_success_report(
+    flaky_test,
+    flaky_plugin,
+    call_info,
+    string_io,
+    mock_io,
+):
+    flaky()(flaky_test)
+    # pylint:disable=protected-access
+    flaky_plugin._flaky_success_report = False
+    # pylint:enable=protected-access
+    call_info.when = 'call'
+    actual_plugin_handles_success = flaky_plugin.add_success(
+        call_info,
+        flaky_test,
+    )
+
+    assert actual_plugin_handles_success is False
+    assert string_io.getvalue() == mock_io.getvalue()
+
+
 class TestFlakyPytestPlugin(object):
     _test_method_name = 'test_method'
 


### PR DESCRIPTION
Now, passing --no-success-flaky-report will cause flaky to only
report about test failures.