### PR TITLE
Fixed an AttributeError in utils.ensure_unicode_string

### DIFF
--- a/flaky/utils.py
+++ b/flaky/utils.py
@@ -13,4 +13,4 @@ def ensure_unicode_string(string):
     try:
         return unicode_type(string)
     except UnicodeDecodeError:
-        return string.decode('utf-8', 'replace')
+        return str(string).decode('utf-8', 'replace')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+
+from flaky.utils import ensure_unicode_string
+from test.base_test_case import TestCase
+
+
+class UtilsTestCase(TestCase):
+    def test_ensure_unicode_string_handles_nonascii_exception_message(self):
+        ex = Exception('\xe2\x80\x93')
+
+        string = ensure_unicode_string(ex)
+        self.assertEqual(string, u'\u2013')


### PR DESCRIPTION
If an object (like an Exception) is passed into ensure_unicode_string and the
exception has non-ASCII bytes in the message, it will raise a UnicodeError
(which will be caught) and then makes the false assumption that the argument
must be a string (and therefore have a .decode() method) resulting in an
AttributeError being raised.

This commit fixes the issue by wrapping it in a call to str() to ensure the
object's string representation is used.