### PR TITLE
Support multiprocessing

### DIFF
--- a/flaky.iml
+++ b/flaky.iml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/flaky" isTestSource="false" />
@@ -10,7 +11,8 @@
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/flaky.egg-info" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 2.7.5 virtualenv at ~/workspaces/flaky/venv" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 2.7.3 virtualenv at ~/.virtualenvs/flaky" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
+

--- a/flaky.iml
+++ b/flaky.iml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
+  <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/flaky" isTestSource="false" />
@@ -11,8 +10,7 @@
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/flaky.egg-info" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 2.7.3 virtualenv at ~/.virtualenvs/flaky" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 2.7.5 virtualenv at ~/workspaces/flaky/venv" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>
-

--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-from io import StringIO
 import multiprocessing
 from flaky import defaults
 from flaky.names import FlakyNames

--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -41,13 +41,9 @@ class _FlakyPlugin(object):
         self._stream.extend([
             ensure_unicode_string(test_callable_name),
             message,
-            '\n\t',
-            ensure_unicode_string(err[0]),
-            '\n\t',
-            ensure_unicode_string(err[1]),
-            '\n\t',
-            ensure_unicode_string(err[2]),
-            '\n',
+            "\t" + ensure_unicode_string(err[0]),
+            "\t" + ensure_unicode_string(err[1]),
+            "\t" + ensure_unicode_string(err[2]),
         ])
 
     def _report_final_failure(self, err, flaky, name):
@@ -243,21 +239,17 @@ class _FlakyPlugin(object):
         need_reruns = not self._has_flaky_test_succeeded(flaky)
         if self._flaky_success_report:
             min_passes = flaky[FlakyNames.MIN_PASSES]
-            self._stream.extend([
-                ensure_unicode_string(name),
-                ' passed {0} out of the required {1} times. '.format(
-                    current_passes,
-                    min_passes,
-                ),
-            ])
+            success_string = ensure_unicode_string(name) + ' passed {0} out of the required {1} times. '.format(
+                current_passes,
+                min_passes,
+            )
             if need_reruns:
-                self._stream.extend(
-                    'Running test again until it passes {0} times.'.format(
-                        min_passes,
-                    )
+                success_string += 'Running test again until it passes {0} times.'.format(
+                    min_passes,
                 )
             else:
-                self._stream.extend('Success!')
+                success_string += 'Success!'
+            self._stream.append(success_string)
         if need_reruns:
             self._rerun_test(test)
         return need_reruns
@@ -349,7 +341,7 @@ class _FlakyPlugin(object):
         except UnicodeEncodeError:
             stream.write(value.encode('utf-8', 'replace'))
 
-        stream.write('\n===End Flaky Test Report===\n')
+        stream.write('\n\n===End Flaky Test Report===\n')
 
     @classmethod
     def _copy_flaky_attributes(cls, test, test_class):

--- a/test/test_flaky_plugin.py
+++ b/test/test_flaky_plugin.py
@@ -63,5 +63,5 @@ class TestFlakyPlugin(TestCase):
         stream = StringIO()
         stream.write('ascii stuff')
         # pylint:disable=protected-access
-        self._flaky_plugin._stream.write(message)
+        self._flaky_plugin._stream.append(message)
         self._flaky_plugin._add_flaky_report(stream)


### PR DESCRIPTION
Hi @Jeff-Meadows 

I wanted your feedback, if possible, while I continue to work on this. At this point I need to adjust pytest tests (and I admit I have more experience with nose than with pytest. I'd welcome the assistance but your review is the most valuable!)

If you would rather review when I am done with the work, that is also fine. I can tag you when that time comes, too.

But the reason I'm pinging you now is more about the important concepts, which are as follows:
* This leverages the multiprocessing Manager. This is how I've seen multiprocessing implemented according to the [documentation](https://docs.python.org/2/library/multiprocessing.html), as well as the [xunitmp nose plugin](https://github.com/Ignas/nose_xunitmp).
* Because the manager runs at such a high level, it is essentially a global process, which also matches the above implementation patterns
* Because it is a global process, it is difficult (if not impossible) to mock. So the tests now instead use the global process, clearing its contents at the beginning of each test run. This is the pattern I would expect to implement in the pytest unit tests when I can get to them. 

Thanks for any feedback!