### PR TITLE
Provide multiprocessing support for nose

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 # Whether to measure branch coverage in addition to statement coverage.
 branch = True
 # List of packages or directories, the source to measure during execution.
-source = box
+source = flaky

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,4 @@
+Flaky is an open source project supported by `Box <https://box.com>`_ that was born out of
+our testing framework. This is a list of contributors.
+
+- `@Jeff-Meadows <https://github.com/Jeff-Meadows>`_

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -106,4 +106,5 @@ down issues.
 
 Finally, please add a note in HISTORY.rst under the Upcoming section
 detailing what's new in your change. These will become the release
-notes for the next release.
+notes for the next release. In addition, feel free to add yourself to
+AUTHORS.rst if you aren't already listed.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Release History
 Upcoming
 ++++++++
 
+**Bugfixes**
+- The flaky report is now available under nose with the multiprocessing plugin.
+
 2.3.0 (2015-10-15)
 ++++++++++++++++++
 

--- a/flaky/flaky_nose_plugin.py
+++ b/flaky/flaky_nose_plugin.py
@@ -20,10 +20,9 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
     def __init__(self):
         super(FlakyPlugin, self).__init__()
         self._logger = logging.getLogger('nose.plugins.flaky')
-        # override base implementation of _stream
+        self._flaky_result = None
         self._nose_result = None
         self._flaky_report = True
-        self._flaky_result = None
         self._force_flaky = False
         self._max_runs = None
         self._min_passes = None
@@ -44,6 +43,21 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
         parser.add_option_group(group)
 
     def _get_stream(self, multiprocess=False):
+        """
+        Get the stream used to store the flaky report.
+        If this nose run is going to use the multiprocess plugin, then use
+        a multiprocess-list backed StringIO proxy; otherwise, use the default
+        stream.
+
+        :param multiprocess:
+            Whether or not this test run is configured for multiprocessing.
+        :type multiprocess:
+            `bool`
+        :return:
+            The stream to use for storing the flaky report.
+        :rtype:
+            :class:`StringIO` or :class:`MultiprocessingStringIO`
+        """
         if multiprocess:
             from flaky.multiprocess_string_io import MultiprocessingStringIO
             return MultiprocessingStringIO()

--- a/flaky/multiprocess_string_io.py
+++ b/flaky/multiprocess_string_io.py
@@ -1,0 +1,42 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+import multiprocessing
+
+
+class MultiprocessingStringIO(object):
+    """
+    Provide an interface to the multiprocessing ListProxy. The
+    multiprocessing ListProxy is a global object that is instantiated before
+    this class would be called, so this is an object class.
+    """
+
+    _manager = multiprocessing.Manager()
+    proxy = _manager.list()  # pylint:disable=no-member
+
+    def __init__(self):
+        """
+        Interface with the MP_STREAM ListProxy object
+        """
+        super(MultiprocessingStringIO, self).__init__()
+
+    def getvalue(self):
+        """
+        Shadow the StringIO method
+        """
+        return ''.join(i for i in self.proxy)
+
+    def writelines(self, content_list):
+        """
+        Shadow the StringIO method. Ingests a list and
+        translates that to a string
+        """
+        # every time we see a "\n" we should make a new list item
+
+        for item in content_list:
+            self.write(item)
+
+    def write(self, content):
+        content.strip('\n')
+        self.proxy.append(content)

--- a/flaky/multiprocess_string_io.py
+++ b/flaky/multiprocess_string_io.py
@@ -7,9 +7,9 @@ import multiprocessing
 
 class MultiprocessingStringIO(object):
     """
-    Provide an interface to the multiprocessing ListProxy. The
-    multiprocessing ListProxy is a global object that is instantiated before
-    this class would be called, so this is an object class.
+    Provide a StringIO-like interface to the multiprocessing ListProxy. The
+    multiprocessing ListProxy needs to be instantiated before the flaky plugin
+    is configured, so the list is created as a class variable.
     """
 
     _manager = multiprocessing.Manager()
@@ -23,20 +23,22 @@ class MultiprocessingStringIO(object):
 
     def getvalue(self):
         """
-        Shadow the StringIO method
+        Shadow the StringIO.getvalue method.
         """
         return ''.join(i for i in self.proxy)
 
     def writelines(self, content_list):
         """
-        Shadow the StringIO method. Ingests a list and
+        Shadow the StringIO.writelines method. Ingests a list and
         translates that to a string
         """
-        # every time we see a "\n" we should make a new list item
 
         for item in content_list:
             self.write(item)
 
     def write(self, content):
+        """
+        Shadow the StringIO.write method.
+        """
         content.strip('\n')
         self.proxy.append(content)

--- a/test/test_multiprocess_string_io.py
+++ b/test/test_multiprocess_string_io.py
@@ -1,0 +1,49 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from genty import genty, genty_dataset
+from io import StringIO
+
+from test.base_test_case import TestCase
+
+
+@genty
+class TestMultiprocessStringIO(TestCase):
+    _unicode_string = 'Plain Hello'
+    _unicode_string_non_ascii = 'ńőń ȁŝćȉȉ ŝƭȕƒƒ'
+
+    def setUp(self):
+        super(TestMultiprocessStringIO, self).setUp()
+        from flaky.multiprocess_string_io import MultiprocessingStringIO
+        self._string_io = StringIO()
+        self._mp_string_io = MultiprocessingStringIO()
+        del self._mp_string_io.proxy[:]
+        self._string_ios = (self._string_io, self._mp_string_io)
+
+    @genty_dataset(
+        no_writes=([], ''),
+        one_write=([_unicode_string], _unicode_string),
+        two_writes=(
+            [_unicode_string, _unicode_string_non_ascii],
+            '{0}{1}'.format(_unicode_string, _unicode_string_non_ascii),
+        )
+    )
+    def test_write_then_read(self, writes, expected_value):
+        for string_io in self._string_ios:
+            for item in writes:
+                string_io.write(item)
+            self.assertEqual(string_io.getvalue(), expected_value)
+
+    @genty_dataset(
+        no_writes=([], ''),
+        one_write=([_unicode_string], _unicode_string),
+        two_writes=(
+            [_unicode_string, _unicode_string_non_ascii],
+            '{0}{1}'.format(_unicode_string, _unicode_string_non_ascii),
+        )
+    )
+    def test_writelines_then_read(self, lines, expected_value):
+        for string_io in self._string_ios:
+            string_io.writelines(lines)
+            self.assertEqual(string_io.getvalue(), expected_value)

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 [testenv:coverage]
 commands =
     python setup.py develop
-    nosetests --with-flaky --with-coverage --cover-package=flaky --exclude="pytest|test_nose_options_example" --no-flaky-report test/
+    nosetests --with-flaky --with-coverage --cover-package=flaky --exclude="pytest|test_nose_options_example" --no-flaky-report --cover-erase test/
     py.test -k 'example and not nose and not options' --doctest-modules --no-flaky-report --cov flaky --cov-report term-missing  test/
     py.test -p no:flaky --cov flaky --cov-report term-missing test/test_flaky_pytest_plugin.py
 


### PR DESCRIPTION
Specifically, store the stream used in reports with a SyncManager ListProxy
object. Store the flaky results as items in the list, which are then written
out in the report at the end of the nosetests.

Before:

```
===Flaky Test Report===

===End Flaky Test Report===
```

Now:
```
===Flaky Test Report===

test_can_foo passed 1 out of the required 2 times. Running test again until it passes 2 times.
test_can_foo passed 2 out of the required 2 times. Success!
test_cannot_foo failed (1 runs remaining out of 2).
    <type 'exceptions.AssertionError'>
    '1' != u'2'
    <traceback object at 0x20e2dd0>
test_cannot_foo passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
```