### PR TITLE
Refactor pytest plugin.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -94,7 +94,7 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression which should only match correct function names
-function-rgx=[a-z_][a-z0-9_]{2,50}$
+function-rgx=[a-z_][a-z0-9_]{2,60}$
 
 # Regular expression which should only match correct method names
 method-rgx=[a-z_][a-z0-9_]{2,60}$
@@ -134,7 +134,7 @@ docstring-min-length=-1
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=80
+max-line-length=120
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/test/pytest_generate_example/conftest.py
+++ b/test/pytest_generate_example/conftest.py
@@ -5,4 +5,4 @@ from __future__ import unicode_literals
 
 def pytest_generate_tests(metafunc):
     if 'dummy_list' in metafunc.fixturenames:
-        metafunc.parametrize("dummy_list", [[]])
+        metafunc.parametrize("dummy_list", [['foo']])

--- a/test/pytest_generate_example/test_pytest_generate_example.py
+++ b/test/pytest_generate_example/test_pytest_generate_example.py
@@ -14,7 +14,9 @@ def test_something_flaky(dummy_list):
 class TestExample(object):
     _threshold = -1
 
+    @staticmethod
     @flaky
-    def test_flaky_thing_that_fails_then_succeeds(self, dummy_list):
-        self._threshold += 1
-        assert self._threshold >= 1
+    def test_flaky_thing_that_fails_then_succeeds(dummy_list):
+        # pylint:disable=unused-argument
+        TestExample._threshold += 1
+        assert TestExample._threshold >= 1

--- a/test/test_pytest_example.py
+++ b/test/test_pytest_example.py
@@ -19,9 +19,17 @@ def test_something_flaky(dummy_list=[]):
     assert len(dummy_list) > 1
 
 
-class TestExample(object):
-    _threshold = -1
+@pytest.fixture(scope='class')
+def threshold_provider():
+    return {'threshold': -1}
 
+
+@pytest.fixture(scope='class')
+def threshold_provider_2():
+    return {'threshold': -1}
+
+
+class TestExample(object):
     def test_non_flaky_thing(self):
         """Flaky will not interact with this test"""
         pass
@@ -31,23 +39,25 @@ class TestExample(object):
         """Flaky will also not interact with this test"""
         assert self == 1
 
+    @staticmethod
     @flaky(3, 2)
-    def test_flaky_thing_that_fails_then_succeeds(self):
+    def test_flaky_thing_that_fails_then_succeeds(threshold_provider):
         """
         Flaky will run this test 3 times.
         It will fail once and then succeed twice.
         """
-        self._threshold += 1
-        assert self._threshold >= 1
+        threshold_provider['threshold'] += 1
+        assert threshold_provider['threshold'] >= 1
 
+    @staticmethod
     @flaky(3, 2)
-    def test_flaky_thing_that_succeeds_then_fails_then_succeeds(self):
+    def test_flaky_thing_that_succeeds_then_fails_then_succeeds(threshold_provider_2):
         """
         Flaky will run this test 3 times.
         It will succeed once, fail once, and then succeed one more time.
         """
-        self._threshold += 1
-        assert self._threshold != 1
+        threshold_provider_2['threshold'] += 1
+        assert threshold_provider_2['threshold'] != 1
 
     @flaky(2, 2)
     def test_flaky_thing_that_always_passes(self):
@@ -68,26 +78,28 @@ class TestExample(object):
 class TestExampleFlakyTests(object):
     _threshold = -1
 
-    def test_flaky_thing_that_fails_then_succeeds(self):
+    @staticmethod
+    def test_flaky_thing_that_fails_then_succeeds():
         """
         Flaky will run this test twice.
         It will fail once and then succeed.
         """
-        self._threshold += 1
-        assert self._threshold >= 1
+        TestExampleFlakyTests._threshold += 1
+        assert TestExampleFlakyTests._threshold >= 1
 
 
 @flaky
 class TestExampleFlakyTestCase(TestCase):
     _threshold = -1
 
-    def test_flaky_thing_that_fails_then_succeeds(self):
+    @staticmethod
+    def test_flaky_thing_that_fails_then_succeeds():
         """
         Flaky will run this test twice.
         It will fail once and then succeed.
         """
-        self._threshold += 1
-        assert self._threshold >= 1
+        TestExampleFlakyTestCase._threshold += 1
+        assert TestExampleFlakyTestCase._threshold >= 1
 
 
 class TestFlakySubclass(TestExampleFlakyTestCase):
@@ -101,3 +113,15 @@ def _test_flaky_doctest():
     True
     """
     return True
+
+
+@pytest.fixture
+def my_fixture():
+    return 42
+
+
+@flaky
+def test_requiring_my_fixture(my_fixture, dummy_list=[]):
+    # pylint:disable=dangerous-default-value,unused-argument
+    dummy_list.append(0)
+    assert len(dummy_list) > 1

--- a/test/test_pytest_options_example.py
+++ b/test/test_pytest_options_example.py
@@ -18,28 +18,30 @@ def test_something_flaky(dummy_list=[]):
 class TestExample(object):
     _threshold = -2
 
+    @staticmethod
     @flaky(3, 1)
-    def test_flaky_thing_that_fails_then_succeeds(self):
+    def test_flaky_thing_that_fails_then_succeeds():
         """
         Flaky will run this test 3 times.
         It will fail twice and then succeed once.
         This ensures that the flaky decorator overrides any command-line
         options we specify.
         """
-        self._threshold += 1
-        assert self._threshold >= 1
+        TestExample._threshold += 1
+        assert TestExample._threshold >= 1
 
 
 @flaky(3, 1)
 class TestExampleFlakyTests(object):
     _threshold = -2
 
-    def test_flaky_thing_that_fails_then_succeeds(self):
+    @staticmethod
+    def test_flaky_thing_that_fails_then_succeeds():
         """
         Flaky will run this test 3 times.
         It will fail twice and then succeed once.
         This ensures that the flaky decorator on a test suite overrides any
         command-line options we specify.
         """
-        self._threshold += 1
-        assert self._threshold >= 1
+        TestExampleFlakyTests._threshold += 1
+        assert TestExampleFlakyTests._threshold >= 1

--- a/tox.ini
+++ b/tox.ini
@@ -23,13 +23,13 @@ commands =
 
 [testenv:pep8]
 commands =
-    pep8 flaky
-    pep8 test
+    pep8 --ignore=E501 flaky
+    pep8 --ignore=E501 test
 
 [testenv:pylint]
 commands =
     pylint --rcfile=.pylintrc flaky
-    pylint --rcfile=.pylintrc test -d C0330
+    pylint --rcfile=.pylintrc test -d C0330,W0621
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
This commit partially rewrites the pytest plugin so that retrying a test
includes setup and teardown of test fixtures.

This is a potentially **breaking change**, but it actually matches up
with how the nose plugin works and is probably what most users would want.

Fixes #53.