### PR TITLE
Fix return values of nose plugin hooks.

### DIFF
--- a/flaky/flaky_nose_plugin.py
+++ b/flaky/flaky_nose_plugin.py
@@ -150,7 +150,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
         want_error = self._handle_test_error_or_failure(test, err)
         if not want_error and id(test) in self._tests_that_reran:
             self._nose_result.addError(test, err)
-        return want_error
+        return want_error or None
 
     def handleFailure(self, test, err):
         """
@@ -176,7 +176,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
         want_failure = self._handle_test_error_or_failure(test, err)
         if not want_failure and id(test) in self._tests_that_reran:
             self._nose_result.addFailure(test, err)
-        return want_failure
+        return want_failure or None
 
     def addSuccess(self, test):
         """
@@ -199,7 +199,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
             `bool`
         """
         # pylint:disable=invalid-name
-        return self._handle_test_success(test)
+        return self._handle_test_success(test) or None
 
     def report(self, stream):
         """

--- a/test/test_nose/test_flaky_nose_plugin.py
+++ b/test/test_nose/test_flaky_nose_plugin.py
@@ -281,7 +281,7 @@ class TestFlakyNosePlugin(TestCase):
             )
 
         self.assertEqual(
-            expected_plugin_handles_failure,
+            expected_plugin_handles_failure or None,
             actual_plugin_handles_failure,
             'Expected plugin{0} to handle the test run, but it did{1}.'.format(
                 ' to' if expected_plugin_handles_failure else '',
@@ -382,7 +382,7 @@ class TestFlakyNosePlugin(TestCase):
         )
 
         self.assertEqual(
-            expected_plugin_handles_success,
+            expected_plugin_handles_success or None,
             actual_plugin_handles_success,
             'Expected plugin{0} to handle the test run, but it did{1}.'.format(
                 ' not' if expected_plugin_handles_success else '',


### PR DESCRIPTION
Fixes #88

Nose plugin docs [0] say to return None from a hook to allow other
plugins to see the test. Flaky was returning False when it wanted
other plugins to see the test, which was causing incompatibility
with other plugins. This commit returns None from the addSuccess,
handleError, and handleFailure hooks where False would have been
returned (indicating that flaky was not handling the test).

[0]: http://nose.readthedocs.org/en/latest/plugins/interface.html#nose.plugins.base.IPluginInterface.addSuccess