### PR TITLE
Don't retry @skipped tests.

### DIFF
--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -86,7 +86,8 @@ class FlakyPlugin(_FlakyPlugin):
                 if passed:
                     should_rerun = self.add_success(item)
                 else:
-                    should_rerun = self.add_failure(item, call_info.excinfo)
+                    skipped = call_info.excinfo.typename == 'Skipped'
+                    should_rerun = not skipped and self.add_failure(item, call_info.excinfo)
                     if not should_rerun:
                         item.excinfo = call_info.excinfo
         finally:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def main():
     base_dir = dirname(__file__)
     setup(
         name='flaky',
-        version='3.1.0',
+        version='3.1.1',
         description='Plugin for nose or py.test that automatically reruns flaky tests.',
         long_description=open(join(base_dir, 'README.rst')).read(),
         author='Box',

--- a/test/test_pytest/test_pytest_example.py
+++ b/test/test_pytest/test_pytest_example.py
@@ -2,11 +2,11 @@
 
 from __future__ import unicode_literals
 
-from unittest import TestCase
 # pylint:disable=import-error
 import pytest
 # pylint:enable=import-error
 from flaky import flaky
+from test.test_case_base import TestCase, skip
 
 
 # This is an end-to-end example of the flaky package in action. Consider it
@@ -133,3 +133,9 @@ class TestExampleRerunFilter(object):
         # pylint:disable=no-self-use
         TestExampleRerunFilter._threshold += 1
         assert TestExampleRerunFilter._threshold >= 1
+
+
+@skip('This test always fails')
+@flaky
+def test_something_that_always_fails_but_should_be_skipped():
+    assert 0


### PR DESCRIPTION
Fixes #96, which is a regression on #43.
When the py.test plugin was refactored in #76, the logic to not
retry Skipped tests was accidentally removed. This commit restores the logic
and adds a test so that we won't regress on this again.