### PR TITLE
WIP: print nice tracebacks in the flaky test report

### DIFF
--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 from io import StringIO
+from traceback import format_exception
 from flaky import defaults
 from flaky.names import FlakyNames
 from flaky.utils import ensure_unicode_string
@@ -36,15 +37,15 @@ class _FlakyPlugin(object):
         Add messaging about a test failure to the stream, which will be
         printed by the plugin's report method.
         """
+        import types
+        tb = err[2]
+        assert tb is None or isinstance(tb, types.TracebackType), type(tb)
+        tb = ''.join(format_exception(*err)).rstrip()
         self._stream.writelines([
             ensure_unicode_string(test_callable_name),
             message,
             '\n\t',
-            ensure_unicode_string(err[0]),
-            '\n\t',
-            ensure_unicode_string(err[1]),
-            '\n\t',
-            ensure_unicode_string(err[2]),
+            ensure_unicode_string(tb).replace('\n', '\n\t'),
             '\n',
         ])
 

--- a/test/test_nose/test_flaky_nose_plugin.py
+++ b/test/test_nose/test_flaky_nose_plugin.py
@@ -304,11 +304,7 @@ class TestFlakyNosePlugin(TestCase):
                     max_runs - current_runs - 1, max_runs
                 ),
                 '\n\t',
-                unicode_type(self._mock_error[0]),
-                '\n\t',
-                unicode_type(self._mock_error[1]),
-                '\n\t',
-                unicode_type(self._mock_error[2]),
+                'Exception: Error in test_method',
                 '\n',
             ])]
         else:
@@ -332,11 +328,7 @@ class TestFlakyNosePlugin(TestCase):
                     min_passes
                 ),
                 '\n\t',
-                unicode_type(self._mock_error[0]),
-                '\n\t',
-                unicode_type(self._mock_error[1]),
-                '\n\t',
-                unicode_type(self._mock_error[2]),
+                'Exception: Error in test_method',
                 '\n'
             ])]
         self.assertEqual(


### PR DESCRIPTION
I'm submitting this incomplete PR because I want to get your opinion on the
approach.

Fixes #102 when you're using nose.

Breaks everything for pytest users, because the `err` argument, which
conains an (exc_type, exc_value, traceback) tuple, gets a the traceback
as a string.

I don't know if the right thing is to fix the caller to always pass the
same type (i.e. do the TB formatting in the nose plugin and always pass
a string here), or if this method needs to suppot polymorphism directly.