### PR TITLE
Refactor getting test names and callables.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,16 @@ Release History
 Upcoming
 ++++++++
 
+3.2.0 (2016-07-21)
+++++++++++++++++++
+
+- Flaky will completely suppress the flaky report if ``--no-success-flaky-report`` is specified and no tests
+  needed to be rerun.
+
+**Bugfixes**
+- Flaky will no longer cause ``py.test --pep8`` to fail.
+
+
 3.1.0 (2016-22-11)
 ++++++++++++++++++
 

--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -605,6 +605,7 @@ class _FlakyPlugin(object):
         :rtype:
             `unicode`
         """
+        raise NotImplementedError  # pragma: no cover
 
     @classmethod
     def _make_test_flaky(cls, test, max_runs, min_passes):

--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -176,7 +176,7 @@ class _FlakyPlugin(object):
             `bool`
         """
         try:
-            _, _, name = self._get_test_declaration_callable_and_name(test)
+            name = self._get_test_callable_name(test)
         except AttributeError:
             return False
 
@@ -266,7 +266,7 @@ class _FlakyPlugin(object):
             `bool`
         """
         try:
-            _, _, name = self._get_test_declaration_callable_and_name(test)
+            name = self._get_test_callable_name(test)
         except AttributeError:
             return False
         need_reruns = self._should_handle_test_success(test)
@@ -407,7 +407,9 @@ class _FlakyPlugin(object):
         :type test:
             :class:`nose.case.Test`
         """
-        _, test_callable, _ = cls._get_test_declaration_callable_and_name(test)
+        test_callable = cls._get_test_callable(test)
+        if test_callable is None:
+            return
         for attr, value in cls._get_flaky_attributes(test_class).items():
             already_set = hasattr(test, attr)
             if already_set:
@@ -574,21 +576,35 @@ class _FlakyPlugin(object):
         return flaky[FlakyNames.CURRENT_PASSES] >= flaky[FlakyNames.MIN_PASSES]
 
     @classmethod
-    def _get_test_declaration_callable_and_name(cls, test):
+    def _get_test_callable(cls, test):
         """
-        Get the test declaration, the test callable,
-        and test callable name from the test.
+        Get the test callable, from the test.
 
         :param test:
             The test that has raised an error or succeeded
         :type test:
-            :class:`nose.case.Test` or :class:`Function`
+            :class:`nose.case.Test` or :class:`pytest.Item`
         :return:
             The test declaration, callable and name that is being run
         :rtype:
-            `tuple` of `object`, `callable`, `unicode`
+            `callable`
         """
         raise NotImplementedError  # pragma: no cover
+
+    @staticmethod
+    def _get_test_callable_name(test):
+        """
+        Get the name of the test callable from the test.
+
+        :param test:
+            The test that has raised an error or succeeded
+        :type test:
+            :class:`nose.case.Test` or :class:`pytest.Item`
+        :return:
+            The name of the test callable that is being run by the test
+        :rtype:
+            `unicode`
+        """
 
     @classmethod
     def _make_test_flaky(cls, test, max_runs, min_passes):

--- a/flaky/flaky_nose_plugin.py
+++ b/flaky/flaky_nose_plugin.py
@@ -251,16 +251,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
     @staticmethod
     def _get_test_callable_name(test):
         """
-        Get the name of the test callable from the test.
-
-        :param test:
-            The test that has raised an error or succeeded
-        :type test:
-            :class:`nose.case.Test`
-        :return:
-            The name of the test callable that is being run by the test
-        :rtype:
-            `unicode`
+        Base class override.
         """
         _, _, class_and_callable_name = test.address()
         first_dot_index = class_and_callable_name.find('.')
@@ -268,7 +259,7 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
         return test_callable_name
 
     @classmethod
-    def _get_test_declaration_callable_and_name(cls, test):
+    def _get_test_callable(cls, test):
         """
         Base class override.
 
@@ -276,10 +267,6 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
             The test that has raised an error or succeeded
         :type test:
             :class:`nose.case.Test`
-        :return:
-            The test declaration, callable and name that is being run
-        :rtype:
-            `tuple` of `object`, `callable`, `unicode`
         """
         callable_name = cls._get_test_callable_name(test)
         test_callable = getattr(
@@ -287,4 +274,4 @@ class FlakyPlugin(_FlakyPlugin, Plugin):
             callable_name,
             getattr(test.test, 'test', test.test),
         )
-        return test_callable, test_callable, callable_name
+        return test_callable

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -336,9 +336,7 @@ class FlakyPlugin(_FlakyPlugin):
             unparametrized_name = callable_name[:callable_name.index('[')]
         else:
             unparametrized_name = callable_name
-        print test, test.name, callable_name
         test_instance = cls._get_test_instance(test)
-        print test, test.name, callable_name, test_instance
         if hasattr(test_instance, callable_name):
             # Test is a method of a class
             def_and_callable = getattr(test_instance, callable_name)

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -146,7 +146,7 @@ class FlakyPlugin(_FlakyPlugin):
         :rtype:
             ((`type`, :class:`Exception`, :class:`Traceback`) or (None, None, None), `unicode`)
         """
-        _, _, name = self._get_test_declaration_callable_and_name(item)
+        name = self._get_test_callable_name(item)
         call_info = self._call_infos.get(item, {}).get(self._PYTEST_WHEN_CALL, None)
         if call_info is not None and call_info.excinfo:
             err = (call_info.excinfo.type, call_info.excinfo.value, call_info.excinfo.tb)
@@ -313,21 +313,12 @@ class FlakyPlugin(_FlakyPlugin):
     @staticmethod
     def _get_test_callable_name(test):
         """
-        Get the name of the test callable from the test.
-
-        :param test:
-            The test that has raised an error or succeeded
-        :type test:
-            :class:`Function`
-        :return:
-            The name of the test callable that is being run by the test
-        :rtype:
-            `unicode`
+        Base class override.
         """
         return test.name
 
     @classmethod
-    def _get_test_declaration_callable_and_name(cls, test):
+    def _get_test_callable(cls, test):
         """
         Base class override.
 
@@ -345,28 +336,31 @@ class FlakyPlugin(_FlakyPlugin):
             unparametrized_name = callable_name[:callable_name.index('[')]
         else:
             unparametrized_name = callable_name
+        print test, test.name, callable_name
         test_instance = cls._get_test_instance(test)
+        print test, test.name, callable_name, test_instance
         if hasattr(test_instance, callable_name):
             # Test is a method of a class
             def_and_callable = getattr(test_instance, callable_name)
-            return def_and_callable, def_and_callable, callable_name
+            return def_and_callable
         elif hasattr(test_instance, unparametrized_name):
             # Test is a parametrized method of a class
             def_and_callable = getattr(test_instance, unparametrized_name)
-            return def_and_callable, def_and_callable, callable_name
-        elif hasattr(test, 'runner') and hasattr(test.runner, 'run'):
-            # Test is a doctest
-            return test, test.runner.run, callable_name
-        elif hasattr(test.module, callable_name):
-            # Test is a function in a module
-            def_and_callable = getattr(test.module, callable_name)
-            return def_and_callable, def_and_callable, callable_name
-        elif hasattr(test.module, unparametrized_name):
-            # Test is a parametrized function in a module
-            def_and_callable = getattr(test.module, unparametrized_name)
-            return def_and_callable, def_and_callable, callable_name
+            return def_and_callable
+        elif hasattr(test, 'module'):
+            if hasattr(test.module, callable_name):
+                # Test is a function in a module
+                def_and_callable = getattr(test.module, callable_name)
+                return def_and_callable
+            elif hasattr(test.module, unparametrized_name):
+                # Test is a parametrized function in a module
+                def_and_callable = getattr(test.module, unparametrized_name)
+                return def_and_callable
+        elif hasattr(test, 'runtest'):
+            # Test is a doctest or other non-Function Item
+            return test.runtest
         else:
-            return None, None, callable_name
+            return None
 
     def _mark_test_for_rerun(self, test):
         """Base class override. Rerun a flaky test."""

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def main():
     base_dir = dirname(__file__)
     setup(
         name='flaky',
-        version='3.1.1',
+        version='3.2.0',
         description='Plugin for nose or py.test that automatically reruns flaky tests.',
         long_description=open(join(base_dir, 'README.rst')).read(),
         author='Box',


### PR DESCRIPTION
Don't assume that pytest Items have a module attribute.
Fixes #99 Fixes #101