### PR TITLE
Use type "int" for argparse type field instead of a string

### DIFF
--- a/flaky/_flaky_plugin.py
+++ b/flaky/_flaky_plugin.py
@@ -351,7 +351,7 @@ class _FlakyPlugin(object):
             '--max-runs',
             action="store",
             dest="max_runs",
-            type="int",
+            type=int,
             default=2,
             help="If --force-flaky is specified, we will run each test at "
                  "most this many times (unless the test has its own flaky "
@@ -361,7 +361,7 @@ class _FlakyPlugin(object):
             '--min-passes',
             action="store",
             dest="min_passes",
-            type="int",
+            type=int,
             default=1,
             help="If --force-flaky is specified, we will run each test at "
                  "least this many times (unless the test has its own flaky "


### PR DESCRIPTION
This suppresses the following deprecation warnings:

```
/usr/lib/python3.5/site-packages/flaky/_flaky_plugin.py:356: DeprecationWarning: type argument to addoption() is a string 'int'. For parsearg this should be a type. (options: ('--max-runs',))
  help="If --force-flaky is specified, we will run each test at "
/usr/lib/python3.5/site-packages/flaky/_flaky_plugin.py:366: DeprecationWarning: type argument to addoption() is a string 'int'. For parsearg this should be a type. (options: ('--min-passes',))
  help="If --force-flaky is specified, we will run each test at "
```
