### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ flaky
 About
 -----
 
-Flaky is a plugin for nose or py.test that automatically reruns flaky tests.
+Flaky is a plugin for nose or pytest that automatically reruns flaky tests.
 
 Ideally, tests reliably pass or fail, but sometimes test fixtures must rely on components that aren't 100%
 reliable. With flaky, instead of removing those tests or marking them to @skip, they can be automatically
@@ -123,11 +123,11 @@ Like any nose plugin, flaky can be activated via the command line:
 
     nosetests --with-flaky
 
-With py.test, flaky will automatically run. It can, however be disabled via the command line:
+With pytest, flaky will automatically run. It can, however be disabled via the command line:
 
 .. code-block:: console
 
-    py.test -p no:flaky
+    pytest -p no:flaky
 
 Command line arguments
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/flaky/flaky_pytest_plugin.py
+++ b/flaky/flaky_pytest_plugin.py
@@ -25,7 +25,7 @@ class FlakyXdist(object):
 
 class FlakyPlugin(_FlakyPlugin):
     """
-    Plugin for py.test that allows retrying flaky tests.
+    Plugin for pytest that allows retrying flaky tests.
 
     """
     runner = None
@@ -44,7 +44,7 @@ class FlakyPlugin(_FlakyPlugin):
         """
         Pytest hook to override how tests are run.
 
-        Runs a test collected by py.test.
+        Runs a test collected by pytest.
         - First, monkey patches the builtin runner module to call back to
         FlakyPlugin.call_runtest_hook rather than its own.
         - Then defers to the builtin runner module to run the test,
@@ -52,11 +52,11 @@ class FlakyPlugin(_FlakyPlugin):
         - Reports test results to the flaky report.
 
         :param item:
-            py.test wrapper for the test function to be run
+            pytest wrapper for the test function to be run
         :type item:
             :class:`Function`
         :param nextitem:
-            py.test wrapper for the next test function to be run
+            pytest wrapper for the next test function to be run
         :type nextitem:
             :class:`Function`
         :return:
@@ -102,7 +102,7 @@ class FlakyPlugin(_FlakyPlugin):
         Had to be patched to avoid reporting about test retries.
 
         :param item:
-            py.test wrapper for the test function to be run
+            pytest wrapper for the test function to be run
         :type item:
             :class:`Function`
         :param when:
@@ -140,7 +140,7 @@ class FlakyPlugin(_FlakyPlugin):
         Get the test name and error tuple from a test item.
 
         :param item:
-            py.test wrapper for the test function to be run
+            pytest wrapper for the test function to be run
         :type item:
             :class:`Function`
         :return:
@@ -263,7 +263,7 @@ class FlakyPlugin(_FlakyPlugin):
         CallInfo so the tests can be rerun if necessary.
 
         :param item:
-            py.test wrapper for the test function to be run
+            pytest wrapper for the test function to be run
         :type item:
             :class:`Function`
         """
@@ -284,7 +284,7 @@ class FlakyPlugin(_FlakyPlugin):
         that have not yet been achieved; retry if necessary.
 
         :param item:
-            py.test wrapper for the test function that has succeeded
+            pytest wrapper for the test function that has succeeded
         :type item:
             :class:`Function`
         """
@@ -298,7 +298,7 @@ class FlakyPlugin(_FlakyPlugin):
         that have not yet been achieved; retry if necessary.
 
         :param item:
-            py.test wrapper for the test function that has succeeded
+            pytest wrapper for the test function that has succeeded
         :type item:
             :class:`Function`
         :param err:

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def main():
     setup(
         name='flaky',
         version='3.4.0',
-        description='Plugin for nose or py.test that automatically reruns flaky tests.',
+        description='Plugin for nose or pytest that automatically reruns flaky tests.',
         long_description=open(join(base_dir, 'README.rst')).read(),
         author='Box',
         author_email='oss@box.com',

--- a/tox.ini
+++ b/tox.ini
@@ -16,11 +16,11 @@ deps = -rrequirements-dev.txt
 usedevelop = True
 commands =
     nosetests --with-flaky --exclude="test_nose_options_example" test/test_nose/
-    py.test -k 'example and not options' --doctest-modules test/test_pytest/
-    py.test -k 'example and not options' -n 1 test/test_pytest/
-    py.test -p no:flaky test/test_pytest/test_flaky_pytest_plugin.py
+    pytest -k 'example and not options' --doctest-modules test/test_pytest/
+    pytest -k 'example and not options' -n 1 test/test_pytest/
+    pytest -p no:flaky test/test_pytest/test_flaky_pytest_plugin.py
     nosetests --with-flaky --force-flaky --max-runs 2 test/test_nose/test_nose_options_example.py
-    py.test --force-flaky --max-runs 2  test/test_pytest/test_pytest_options_example.py
+    pytest --force-flaky --max-runs 2  test/test_pytest/test_pytest_options_example.py
 
 [testenv:pep8]
 commands =
@@ -36,8 +36,8 @@ commands =
 commands =
     python setup.py develop
     nosetests --with-flaky --with-coverage --cover-package=flaky --exclude="test_nose_options_example" --no-flaky-report --cover-erase test/test_nose/
-    py.test -k 'example and not options' --doctest-modules --no-flaky-report --cov flaky --cov-report term-missing  test/test_pytest/
-    py.test -p no:flaky --cov flaky --cov-report term-missing test/test_pytest/test_flaky_pytest_plugin.py
+    pytest -k 'example and not options' --doctest-modules --no-flaky-report --cov flaky --cov-report term-missing  test/test_pytest/
+    pytest -p no:flaky --cov flaky --cov-report term-missing test/test_pytest/test_flaky_pytest_plugin.py
 
 [testenv:readme]
 deps =


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot