### PR TITLE
Do not print report if there were no tests marked as 'flaky' (#116)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Release History
 Upcoming
 ++++++++
 
+- Do not print an empty report if no tests marked 'flaky' were ran at all (#116).
+
 3.5.1 (2019-01-09)
 ++++++++++++++++++
 


### PR DESCRIPTION
This fixes #116 . In particular, if there are tests marked `flaky`, but they are deselected by pytest (e.g. with `-k` flag), then no report will be printed as well. In particular, that removes any extra output when running pytest on tests which do not use `flaky`, but `flaky` is installed.

I think that this change may use some end-to-end automatic tests, but I'm not sure where or how to add them. Any suggestions?

I've tested it locally, though: created a virtualenv with `pytest`, ran `setup.py install` and checked that the following file prints report when `py.test` without parameters and does not print report when run with `-k test_foo`:

```
from flaky import flaky

def test_foo():
    assert 2 == 3

@flaky
def test_bar():
    assert 2 == 3
```