### PR TITLE
Refactor pytest plugin to not monkey patch call_runtest_hook.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Release History
 Upcoming
 ++++++++
 
+**Bugfixes**
+- Reraise ``KeyboardInterrupt`` when running tests under pytest.
+
 
 3.6.0 (2019-06-25)
 ++++++++++++++++++

--- a/test/test_pytest/test_flaky_pytest_plugin.py
+++ b/test/test_pytest/test_flaky_pytest_plugin.py
@@ -110,9 +110,9 @@ class MockConfig(object):
         # pylint:disable=unused-argument,no-self-use
         return False
 
-    def getoption(self, key):
+    def getoption(self, key, default):
         # pylint:disable=unused-argument,no-self-use
-        return False
+        return default
 
 
 @pytest.fixture

--- a/test/test_pytest/test_flaky_pytest_plugin.py
+++ b/test/test_pytest/test_flaky_pytest_plugin.py
@@ -110,6 +110,10 @@ class MockConfig(object):
         # pylint:disable=unused-argument,no-self-use
         return False
 
+    def getoption(self, key):
+        # pylint:disable=unused-argument,no-self-use
+        return False
+
 
 @pytest.fixture
 def mock_config():


### PR DESCRIPTION
A previous refactor (#74) enabled this, but I didn't notice.
Previously, flaky stored information about test reruns inside a
CallInfo subclass. call_runtest_hook was monkey patched so that
flaky could ensure that subclass was created. #74 moved that info
into the plugin, so the monkey patch was no longer doing anything
special.

However, over time, flaky's implementation diverged from pytest's.
This caused #139 and #156.

This commit removes the monkey patch, and flaky now uses pytest's
implementation, which fixes those issues and is more future proof.