### PR TITLE
Simplify flaky dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -rrequirements.txt
 coveralls
-genty
 mock
 ordereddict
 pycodestyle

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 -rrequirements.txt
 coveralls
-mock
 ordereddict
 pycodestyle
 pylint


### PR DESCRIPTION
With the development of the standard library it is not necessary to use external modules `mock` and `genty`, because the functionality is available by default.